### PR TITLE
Fix typo in "--not-production" flag

### DIFF
--- a/egicli/endpoint.py
+++ b/egicli/endpoint.py
@@ -232,7 +232,7 @@ def token(
 @click.option(
     "--service-type", default="org.openstack.nova", help="Service type in GOCDB"
 )
-@click.option("--production/--not-producton", default=True, help="Production status")
+@click.option("--production/--not-production", default=True, help="Production status")
 @click.option("--monitored/--not-monitored", default=True, help="Monitoring status")
 @click.option(
     "--site", help="Name of the site", default=lambda: os.environ.get("EGI_SITE", None)


### PR DESCRIPTION
Trivial amendment, but it caused me some confusion
when trying to work with egicli, and comparing with
a colleague's output, whom had this working fine. It
took a while of staring at the output, but finally saw
it. "--not-producton" was missing an 'i'. Thanks!

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
-->

# Summary 

<!-- Describe in plain English what this PR does -->

----
<!-- Add the related issue here, e.g. #6 -->
**Related issue :**
